### PR TITLE
Idempotence when using delete command

### DIFF
--- a/library/openwrt_uci.sh
+++ b/library/openwrt_uci.sh
@@ -288,7 +288,7 @@ main() {
         get)
             uci_get; exit 0;;
         delete)
-            final uci $command "$key${value:+=$value}";;
+            uci -q get "$key" 2>/dev/null && final uci $command "$key${value:+=$value}" || exit 0;;
         rename)
             final uci $command "$key=${name:-$value}";;
         revert)


### PR DESCRIPTION
When delete command in uci is called for non-existent key - it will no fail, but succeed with no changes.